### PR TITLE
Add object-shorthand rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,8 +92,10 @@ module.exports = {
 		'comma-dangle': ['warn', 'always-multiline'],
 		// Allow shallow import of @vue/test-utils in order to be able to use it in 
 		// the src folder
-		"node/no-unpublished-import": ["error", {
-			"allowModules": ["@vue/test-utils"]
-		}]
+		'node/no-unpublished-import': ['error', {
+			'allowModules': ['@vue/test-utils']
+		}],
+		// require object literal shorthand syntax
+		'object-shorthand': ['error', 'always'],
 	},
 }


### PR DESCRIPTION
This PR adds the object-shorthand syntax rule. I also took the liberty to change the double-quotes to single-quotes for the last rule.

Closes #35.