### PR TITLE
Require a space before async arrow function parentheses

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,11 @@ module.exports = {
 	plugins: ['vue', 'node', 'jsdoc'],
 	rules: {
 		// space before function ()
-		'space-before-function-paren': ['error', 'never'],
+		'space-before-function-paren': ['error', {
+			anonymous: 'never',
+			named: 'never',
+			asyncArrow: 'always',
+		}],
 		// stay consistent with array brackets
 		'array-bracket-newline': ['error', 'consistent'],
 		// tabs only for indentation


### PR DESCRIPTION
Updates `space-before-function-paren` rule to require a space before async arrow function parentheses as described in the [docs](https://eslint.org/docs/rules/space-before-function-paren#options)