### PR TITLE
Fix license header tags spacing

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,11 @@ module.exports = {
 		// force proper JSDocs
 		'jsdoc/require-returns': 0,
 		'jsdoc/require-returns-description': 0,
+		'jsdoc/tag-lines': ['warn', 'never', { count: 0, tags: {
+			copyright: { count: 1, lines: 'always' },
+			author: { count: 1, lines: 'always' },
+			license: { count: 1, lines: 'always' },
+		}}],
 		// disallow use of "var"
 		'no-var': 'error',
 		// suggest using const


### PR DESCRIPTION
## Before
```js
/**
 * @copyright Copyright (c) 2019 John Molakvoæ <skjnldsv@protonmail.com>
 * @author John Molakvoæ <skjnldsv@protonmail.com>
 * @license AGPL-3.0-or-later
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU Affero General Public License as
 * published by the Free Software Foundation, either version 3 of the
 * License, or (at your option) any later version.
 *
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 * GNU Affero General Public License for more details.
 *
 * You should have received a copy of the GNU Affero General Public License
 * along with this program. If not, see <http://www.gnu.org/licenses/>.
 */

```
## After
```js
/**
 * @copyright Copyright (c) 2019 John Molakvoæ <skjnldsv@protonmail.com>
 *
 * @author John Molakvoæ <skjnldsv@protonmail.com>
 *
 * @license AGPL-3.0-or-later
 *
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU Affero General Public License as
 * published by the Free Software Foundation, either version 3 of the
 * License, or (at your option) any later version.
 *
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 * GNU Affero General Public License for more details.
 *
 * You should have received a copy of the GNU Affero General Public License
 * along with this program. If not, see <http://www.gnu.org/licenses/>.
 */

```