### PR TITLE
Allow component names to be single-word

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,6 +95,8 @@ module.exports = {
 			'singleline': 'beside',
 			'multiline': 'below',
 		}],
+		// Allow single-word components names
+		'vue/multi-word-component-names': ['off'],
 		// custom event naming convention
 		'vue/custom-event-name-casing': ['error', 'kebab-case', {
 			// allows custom xxxx:xxx events formats


### PR DESCRIPTION
Introduced with latest `@nextcloud/eslint-config@7.0.0`. Fixing this regression

Ref: https://github.com/nextcloud/viewer/pull/1131