### PR TITLE
Fix usual same-line vue attribute behaviour

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ module.exports = {
 		}],
 		'vue/first-attribute-linebreak': ['error', {
 			'singleline': 'beside',
-			'multiline': 'below',
+			'multiline': 'beside',
 		}],
 		// Allow single-word components names
 		'vue/multi-word-component-names': ['off'],


### PR DESCRIPTION
Sorry for the regression.

Here is the fix (from 7.0.1 to this PR)
![image](https://user-images.githubusercontent.com/14975046/150370593-6218119b-f515-4a7f-86db-07e0cb91c341.png)

Ref: https://github.com/nextcloud/server/pull/30729