### PR TITLE
v7.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [v7.0.2](https://github.com/nextcloud/eslint-config/tree/v7.0.2) (2022-01-20)
+
+[Full Changelog](https://github.com/nextcloud/eslint-config/compare/v7.0.1...v7.0.2)
+
+**Fixed:**
+
+- Fix usual same-line vue attribute behaviour [\#272](https://github.com/nextcloud/eslint-config/pull/272) ([skjnldsv](https://github.com/skjnldsv))
+
+**Dependency updates:**
+
+- Bump eslint from 8.6.0 to 8.7.0 [\#271](https://github.com/nextcloud/eslint-config/pull/271) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Bump @babel/core from 7.16.7 to 7.16.10 [\#273](https://github.com/nextcloud/eslint-config/pull/273) ([dependabot[bot]](https://github.com/apps/dependabot))
+
 ## [v7.0.1](https://github.com/nextcloud/eslint-config/tree/v7.0.1) (2022-01-17)
 
 [Full Changelog](https://github.com/nextcloud/eslint-config/compare/v7.0.0...v7.0.1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@nextcloud/eslint-config",
-	"version": "7.0.1",
+	"version": "7.0.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@nextcloud/eslint-config",
-			"version": "7.0.1",
+			"version": "7.0.2",
 			"license": "AGPL-3.0-or-later",
 			"devDependencies": {
 				"@babel/core": "^7.13.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/eslint-config",
-	"version": "7.0.1",
+	"version": "7.0.2",
 	"description": "Eslint shared config for nextcloud vue.js apps",
 	"main": "index.js",
 	"repository": {


### PR DESCRIPTION
# Changes

## [v7.0.2](https://github.com/nextcloud/eslint-config/tree/v7.0.2) (2022-01-20)

[Full Changelog](https://github.com/nextcloud/eslint-config/compare/v7.0.1...v7.0.2)

**Fixed:**

- Fix usual same-line vue attribute behaviour [\#272](https://github.com/nextcloud/eslint-config/pull/272) ([skjnldsv](https://github.com/skjnldsv))

**Dependency updates:**

- Bump eslint from 8.6.0 to 8.7.0 [\#271](https://github.com/nextcloud/eslint-config/pull/271) ([dependabot[bot]](https://github.com/apps/dependabot))
- Bump @babel/core from 7.16.7 to 7.16.10 [\#273](https://github.com/nextcloud/eslint-config/pull/273) ([dependabot[bot]](https://github.com/apps/dependabot))

---

# Release steps after merge

- [ ] Create a new release with proper changelog https://github.com/nextcloud/eslint-config/releases/new