### PR TITLE
Add import extension rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,5 +111,9 @@ module.exports = {
 		}],
 		// require object literal shorthand syntax
 		'object-shorthand': ['error', 'always'],
+		// Warn when file extensions are not used on import paths
+		'import/extensions': ['warn', 'always', {
+			ignorePackages: true,
+		}],
 	},
 }


### PR DESCRIPTION
Warn when file extensions are not used on imports paths with the [import/extensions rule](https://github.com/import-js/eslint-plugin-import/blob/v2.25.4/docs/rules/extensions.md), this is to stay up-to-date with the ecosystem e.g. [Node.js 14 docs](https://nodejs.org/docs/latest-v14.x/api/esm.html#esm_mandatory_file_extensions)

In future we may want to set this to `error`

Also see https://github.com/nextcloud/webpack-vue-config/pull/297