### PR TITLE
Resolve js/vue files after moving to eslint-plugin-n

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = {
 	],
 	settings: {
 		'import/resolver': {
-			node: {
+			n: {
 				paths: ['src'],
 				extensions: ['.js', '.vue'],
 			},


### PR DESCRIPTION
Otherwise lint will fail if no extension is provided with node 16 and the latest release of eslint-config