### PR TITLE
Allow TypeScript syntax in JSDoc comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,9 +31,10 @@ module.exports = {
 		},
 		jsdoc: {
 			tagNamePreference: {
-				returns: 'return'
-			}
-		}
+				returns: 'return',
+			},
+			mode: 'typescript',
+		},
 	},
 	plugins: ['vue', 'n', 'jsdoc'],
 	rules: {


### PR DESCRIPTION
Allow usage of TypeScript syntax e.g.

```js
/**
 * @type {import('vue').Component}
 */
const component = new Vue()
```

Documentation https://github.com/gajus/eslint-plugin-jsdoc/blob/v39.2.1/README.md#mode