### PR TITLE
feat: ignore camelcase rule for __webpack variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,6 +118,12 @@ module.exports = {
 		'import/extensions': ['warn', 'always', {
 			ignorePackages: true,
 		}],
+		// ignore camelcase for __webpack variables
+		camelcase: ['error', {
+			allow: ['^UNSAFE_', '^__webpack_'],
+			properties: 'never',
+			ignoreGlobals: true,
+		}],
 	},
 	overrides: [
 		{

--- a/tests/eslint-config.test.ts
+++ b/tests/eslint-config.test.ts
@@ -29,3 +29,9 @@ test('TSX is linted', async () => {
 	expect(results).toHaveIssue({ruleId: '@typescript-eslint/no-unused-vars', line: 7})
 	expect(results).toHaveIssueCount(2)
 })
+
+test('ignore camelcase for webpack', async () => {
+	const results = await lintFile('fixtures/webpack-nonce.js')
+	expect(results).toHaveIssueCount(1)
+	expect(results).toHaveIssue({ruleId: 'no-undef', line: 2 })
+})

--- a/tests/fixtures/webpack-nonce.js
+++ b/tests/fixtures/webpack-nonce.js
@@ -1,0 +1,2 @@
+// ignore camelcase for __webpack_ variables
+__webpack_nonce__ = 'foo_bar'


### PR DESCRIPTION
```
// eslint-disable-next-line camelcase
__webpack_nonce__ = 'foobar'
// eslint-disable-next-line camelcase
__webpack_public_path__ = 'foobar'
```

Motivation: `__webpack_nonce__` will always violate the camelcase rule. 

The error is usually ignored with `// eslint-disable-next-line camelcase`. 
It sounds reasonable to me to add the ignore rule by default. 

An alternative approach could be to define `__webpack_nonce__` as globals. The advantage is that also the un-def violation is gone and globals are by default excluded from the camelcase rule. But it's weird to define `__webpack_nonce` as global for every app using eslint when the variable is only available when bundled with webpack. 