### PR TITLE
fix: Add Typescript overrides for all valid Typescript file extensions

### DIFF
--- a/parts/typescript.js
+++ b/parts/typescript.js
@@ -1,6 +1,6 @@
 /** Rules for typescript */
 module.exports = {
-    files: ['**/*.ts', '**/*.tsx'],
+    files: ['**/*.ts', '**/*.cts', '**/*.mts', '**/*.tsx'],
     extends: [
         '@vue/eslint-config-typescript/recommended',
         'plugin:import/typescript',


### PR DESCRIPTION
Valid Typescript file extensions are:
* `.ts`
* `.mts` (es module Typescript)
* `.cts` (commonjs Typescript)
* `.tsx`