### PR TITLE
v8.3.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Provide config for vue files written in Typescript, use `extends: "@nextcloud/eslint-config/typescript"`.
 - Fully support vue files using the Composition API `<script setup>`.
 
+**Fixed:**
+- fix: Add Typescript overrides for all valid Typescript file extensions by @susnux in https://github.com/nextcloud/eslint-config/pull/567
+
 ## [v8.3.0-beta.0](https://github.com/nextcloud/eslint-config/tree/v8.3.0-beta.0) (2023-05-12)
 
 [Full Changelog](https://github.com/nextcloud/eslint-config/compare/v8.2.1...v8.3.0-beta.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-[Full Changelog](https://github.com/nextcloud/eslint-config/compare/v8.2.1...master)
+## [v8.3.0-beta.1](https://github.com/nextcloud/eslint-config/tree/v8.3.0-beta.1) (2023-06-27)
+
+[Full Changelog](https://github.com/nextcloud/eslint-config/compare/v8.3.0-beta.0...v8.3.0-beta.1)
 
 **Features:**
 - Provide config for vue files written in Typescript, use `extends: "@nextcloud/eslint-config/typescript"`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/eslint-config",
-  "version": "8.3.0-beta.0",
+  "version": "8.3.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/eslint-config",
-  "version": "8.3.0-beta.0",
+  "version": "8.3.0-beta.1",
   "description": "Eslint shared config for nextcloud vue.js apps",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION

## [v8.3.0-beta.1](https://github.com/nextcloud/eslint-config/tree/v8.3.0-beta.1) (2023-06-27)

[Full Changelog](https://github.com/nextcloud/eslint-config/compare/v8.3.0-beta.0...v8.3.0-beta.1)

**Features:**
- Provide config for vue files written in Typescript, use `extends: "@nextcloud/eslint-config/typescript"`.
- Fully support vue files using the Composition API `<script setup>`.