### PR TITLE
fix: allow empty functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **Fixed:**
 - chore: update typescript deps and co by @skjnldsv in https://github.com/nextcloud/eslint-config/pull/569
+- fix: allow empty functions by @skjnldsv in https://github.com/nextcloud/eslint-config/pull/570
 
 ## [v8.3.0-beta.1](https://github.com/nextcloud/eslint-config/tree/v8.3.0-beta.1) (2023-06-27)
 

--- a/parts/typescript.js
+++ b/parts/typescript.js
@@ -21,6 +21,7 @@ module.exports = {
         ],
         // Does not make sense with TypeScript
         'jsdoc/require-param-type': 'off',
+        '@typescript-eslint/no-empty-function': 'off',
     },
     settings: {
         'import/resolver': {


### PR DESCRIPTION
We have a lot of these
![image](https://github.com/nextcloud/eslint-config/assets/14975046/50f9938a-557e-4a9a-b8cb-a0e99fb395e0)
