### PR TITLE
fix(typescript): Allow generic type parameters on function calls

### DIFF
--- a/parts/typescript.js
+++ b/parts/typescript.js
@@ -8,6 +8,10 @@ module.exports = {
 	parser: '@typescript-eslint/parser',
 	parserOptions: {},
 	rules: {
+		// allow for generic type parameters on function calls
+		'func-call-spacing': 'off',
+		'@typescript-eslint/func-call-spacing': 'error',
+		//
 		'n/no-missing-import': 'off',
 		'import/extensions': 'off',
 		'jsdoc/check-tag-names': [


### PR DESCRIPTION
Allow e.g. this for vue `<script setup>`:
```ts
const emit = defineEmits<{
    foo: number
}>()
```