### PR TITLE
fix: Allow `@jest-environment` docblock for jest tests

### DIFF
--- a/parts/base.js
+++ b/parts/base.js
@@ -63,6 +63,14 @@ module.exports = {
 		// ternary on multiline
 		'multiline-ternary': ['error', 'always-multiline'],
 		// force proper JSDocs
+		'jsdoc/check-tag-names': [
+			'warn', {
+				definedTags: [
+					// for jest
+					'jest-environment',
+				],
+			},
+		],
 		'jsdoc/require-returns': 0,
 		'jsdoc/require-returns-description': 0,
 		'jsdoc/tag-lines': ['off'],

--- a/parts/typescript.js
+++ b/parts/typescript.js
@@ -16,10 +16,12 @@ module.exports = {
 		'import/extensions': 'off',
 		'jsdoc/check-tag-names': [
 			'warn', {
-				// for projects using typedoc
 				definedTags: [
+					// for projects using typedoc
 					'notExported',
 					'packageDocumentation',
+					// for jest
+					'jest-environment',
 				],
 			},
 		],


### PR DESCRIPTION
Many of your projects use `@jest-environment` inside tests, so we should allow that docblock.